### PR TITLE
Update README.md with deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## mvt-bench-fixtures
 
+This repository is deprecated and should not be used. Use the `real world` fixtures inside https://github.com/mapbox/mvt-fixtures instead. See https://github.com/mapbox/mvt-fixtures/blob/master/REAL-WORLD.md for the fixtures available and https://github.com/mapbox/vtquery/tree/96d389b5e1f0708192785802ba8d170410de80ea/bench for sample usage.
+
 Sample vector tiles at z14. 210 of 'em. Designed to be used to benchmark decoders.
 
 Contains `mapbox.mapbox-terrain-v2` and `mapbox.mapbox-streets-v7`.


### PR DESCRIPTION
This makes clear that https://github.com/mapbox/mvt-fixtures should be used instead of this repo. 

/cc @mapsam for review
/cc @BergWerkGIS for visibility.